### PR TITLE
Added support for ending a line with a square bracket

### DIFF
--- a/AutoSemiColon.py
+++ b/AutoSemiColon.py
@@ -14,8 +14,8 @@ class AutoSemiColonCommand(sublime_plugin.TextCommand):
         for sel in self.view.sel():
             last = last_bracket = first = sel.end()
             # Find the last bracket
-            while (self.view.substr(last) in [' ', ')']):
-                if (self.view.substr(last) == ')'):
+            while (self.view.substr(last) in [' ', ')', ']']):
+                if (self.view.substr(last) != ' '):
                     last_bracket = last + 1
                 last += 1
 


### PR DESCRIPTION
Simple support for ending a line with a square bracket. This means pressing the semicolon key at the end of accessing an array element will insert a semicolon at the end of the line.
