### PR TITLE
Update keybinding regex to not be so loose

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -2,7 +2,7 @@
 	{
 		"keys": [";"], "command": "auto_semi_colon", "context": [
 			{ "key": "selector", "operator": "equal", "operand": "source - string" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(for(each)?|if|switch|while)[^\\{]+$", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\b(for(each)?|if|switch|while)\\s*\\(", "match_all": true }
 		]
 	}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,7 +2,7 @@
 	{
 		"keys": [";"], "command": "auto_semi_colon", "context": [
 			{ "key": "selector", "operator": "equal", "operand": "source - string" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(for(each)?|if|switch|while)[^\\{]+$", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\b(for(each)?|if|switch|while)\\s*\\(", "match_all": true }
 		]
 	}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -2,7 +2,7 @@
 	{
 		"keys": [";"], "command": "auto_semi_colon", "context": [
 			{ "key": "selector", "operator": "equal", "operand": "source - string" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(for(each)?|if|switch|while)[^\\{]+$", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\b(for(each)?|if|switch|while)\\s*\\(", "match_all": true }
 		]
 	}
 ]


### PR DESCRIPTION
First of all, thanks for this great plugin.  It saves me a lot of annoying keypresses :smile:.

I have noticed lately that certain patterns do not work for inserting semicolons for example the following (insert cursor at position `|`):

```
console.log('inside if'|)
console.log('before this'|)
switchQualityUp(|)
forecast(|)
etc...
```

Basically this is due to https://github.com/vivait/SublimeAutoSemiColon/commit/04bf87424b5cabfe3f6499a29055d61fd8845b57.  I couldn't find much more documentation about this change, but I assume it was related to typing out for loops for example

``` javascript
for (var i = 0; i < things.length; i++) ...
```

The regex as is does not check that the line actually starts with that exact phrase, instead it just checks that it contains it.  So for example any line that contains the word `for` in it will not let you type a semicolon.  Also the end seems to be allowing any character that is not an opening `{` which means that a lot of stuff will be matched.

I made two small tweaks
- Added a word boundary check at the beginning `\b` to guarantee that the line starts with the keyword instead of that it is just contained in the line
- Added a check for an optional number of spaces and a `(` after the keyword 

There is no need to match until the end of the line cause if the current line's preceding text contains `if (`  or `for (` then you know that you do not want to allow the automatic semicolon insertion.
